### PR TITLE
Version 1.5.1

### DIFF
--- a/api.go
+++ b/api.go
@@ -626,8 +626,8 @@ func (c *ContainerID) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON is custom position unmarshaler
 func (ep *ExtensionPosition) UnmarshalJSON(b []byte) error {
-	if string(b) == "none" {
-		*ep = -1
+	if string(b) == "\"none\"" {
+		*ep = ExtensionPosition(-1)
 		return nil
 	}
 

--- a/confluence_test.go
+++ b/confluence_test.go
@@ -48,17 +48,27 @@ func (s *ConfluenceSuite) TestParamsEncoding(c *C) {
 }
 
 func (s *ConfluenceSuite) TestCustomUnmarshalers(c *C) {
-	d := &Date{}
-	d.UnmarshalJSON([]byte("\"2013-03-12T10:36:12.602+04:00\""))
+	var err error
 
+	d := &Date{}
+	err = d.UnmarshalJSON([]byte("\"2013-03-12T10:36:12.602+04:00\""))
+
+	c.Assert(err, IsNil)
 	c.Assert(d.Year(), Equals, 2013)
 	c.Assert(d.Month(), Equals, time.Month(3))
 	c.Assert(d.Day(), Equals, 12)
 
 	t := &Timestamp{}
-	t.UnmarshalJSON([]byte("1523059214803"))
+	err = t.UnmarshalJSON([]byte("1523059214803"))
 
+	c.Assert(err, IsNil)
 	c.Assert(t.Year(), Equals, 2018)
 	c.Assert(t.Month(), Equals, time.Month(4))
 	c.Assert(t.Day(), Equals, 7)
+
+	var e ExtensionPosition
+	err = e.UnmarshalJSON([]byte("\"none\""))
+
+	c.Assert(err, IsNil)
+	c.Assert(e, Equals, ExtensionPosition(-1))
 }

--- a/version.go
+++ b/version.go
@@ -12,7 +12,7 @@ const (
 	NAME = "Go-Confluence"
 
 	// VERSION is package version
-	VERSION = "1.5.0"
+	VERSION = "1.5.1"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //


### PR DESCRIPTION
#### Improvements
* Improved tests for custom unmarshalers

#### Bugfixes
* Fixed bug with decoding `Content.ExtensionPosition`